### PR TITLE
breaking up mousemoved function in all QtPlotter classes and cleaning up some random stuff too

### DIFF
--- a/pytplot/HTMLPlotter/TVarFigure1D.py
+++ b/pytplot/HTMLPlotter/TVarFigure1D.py
@@ -261,7 +261,6 @@ class TVarFigure1D(object):
                                 # Restart the count and add the current val to the list of nan values to remove
                                 count = 0
                                 consec_list.append(nan_keys[val])
-                    print(consec_list)
 
                     times = x.tolist()
                     for elem in consec_list:

--- a/pytplot/QtPlotter/TVarFigure1D.py
+++ b/pytplot/QtPlotter/TVarFigure1D.py
@@ -268,29 +268,40 @@ class TVarFigure1D(pg.GraphicsLayout):
         # if plot window contains position
         if self.plotwindow.sceneBoundingRect().contains(pos):
             mousepoint = self.plotwindow.vb.mapSceneToView(pos)
+
+            # Add crosshairs to plot at the mouse's position
+            self._add_mouse_crosshairs(mousepoint)
+
             # grab x and y mouse locations
             index_x = int(mousepoint.x())
             index_y = round(float(mousepoint.y()), 4)
-            date = (pytplot.tplot_utilities.int_to_str(index_x))[0:10]
-            time = (pytplot.tplot_utilities.int_to_str(index_x))[11:19]
-            # add crosshairs
-            if self._mouseMovedFunction is not None:
-                self._mouseMovedFunction(int(mousepoint.x()))
-                self.vLine.setPos(mousepoint.x())
-                self.hLine.setPos(mousepoint.y())
-                self.vLine.setVisible(True)
-                self.hLine.setVisible(True)
 
-            self.hoverlegend.setVisible(True)
-            self.hoverlegend.setItem("Date:", date)
-            # Allow the user to set x-axis(time) and y-axis data names in crosshairs
-            self.hoverlegend.setItem(pytplot.data_quants[self.tvar_name].xaxis_opt['crosshair'] + ':', time)
-            self.hoverlegend.setItem(pytplot.data_quants[self.tvar_name].yaxis_opt['crosshair'] + ':', str(index_y))
+            # Add legend options to the mouse's crosshairs
+            self._mouse_legend_options(index_x, index_y)
 
         else:
             self.hoverlegend.setVisible(False)
             self.vLine.setVisible(False)
             self.hLine.setVisible(False)
+
+    def _add_mouse_crosshairs(self, mousepoint):
+        # add crosshairs to the mouse's current location
+        if self._mouseMovedFunction is not None:
+            self._mouseMovedFunction(int(mousepoint.x()))
+            self.vLine.setPos(mousepoint.x())
+            self.hLine.setPos(mousepoint.y())
+            self.vLine.setVisible(True)
+            self.hLine.setVisible(True)
+
+    def _mouse_legend_options(self, index_x, index_y):
+        # Set legend options for the mouse crosshairs
+        date = (pytplot.tplot_utilities.int_to_str(index_x))[0:10]
+        time = (pytplot.tplot_utilities.int_to_str(index_x))[11:19]
+        self.hoverlegend.setVisible(True)
+        self.hoverlegend.setItem("Date:", date)
+        # Allow the user to set x-axis(time) and y-axis data names in crosshairs
+        self.hoverlegend.setItem(pytplot.data_quants[self.tvar_name].xaxis_opt['crosshair'] + ':', time)
+        self.hoverlegend.setItem(pytplot.data_quants[self.tvar_name].yaxis_opt['crosshair'] + ':', str(index_y))
 
     def _getyaxistype(self):
         if 'y_axis_type' in pytplot.data_quants[self.tvar_name].yaxis_opt:

--- a/pytplot/QtPlotter/TVarFigureAlt.py
+++ b/pytplot/QtPlotter/TVarFigureAlt.py
@@ -42,7 +42,6 @@ class TVarFigureAlt(pg.GraphicsLayout):
 
         self.curves = []
         self.colors = self._setcolors()
-        self.colormap = self._setcolormap()
 
         self.labelStyle = {'font-size': str(pytplot.data_quants[self.tvar_name].extras['char_size'])+'pt'}
 
@@ -114,7 +113,8 @@ class TVarFigureAlt(pg.GraphicsLayout):
         else:
             return
 
-    def getaxistype(self):
+    @staticmethod
+    def getaxistype():
         axis_type = 'altitude'
         link_y_axis = False
         return axis_type, link_y_axis
@@ -129,26 +129,38 @@ class TVarFigureAlt(pg.GraphicsLayout):
         # if plot window contains position
         if self.plotwindow.sceneBoundingRect().contains(pos):
             mousepoint = self.plotwindow.vb.mapSceneToView(pos)
+
+            # Add crosshairs to plot at the mouse's position
+            self._add_mouse_crosshairs(mousepoint)
+
             # grab x and y mouse locations
             index_x = int(mousepoint.x())
             index_y = int(mousepoint.y())
-            # add crosshairs
-            if self._mouseMovedFunction is not None:
-                self._mouseMovedFunction(int(mousepoint.x()))
-                self.vLine.setPos(mousepoint.x())
-                self.hLine.setPos(mousepoint.y())
-                self.vLine.setVisible(True)
-                self.hLine.setVisible(True)
 
-            # Set legend options
-            self.hoverlegend.setVisible(True)
-            # Allow the user to set x-axis(time) and y-axis data names in crosshairs
-            self.hoverlegend.setItem(pytplot.data_quants[self.tvar_name].xaxis_opt['crosshair'] + ':', index_x)
-            self.hoverlegend.setItem(pytplot.data_quants[self.tvar_name].yaxis_opt['crosshair'] + ':', index_y)
+            # Add legend options to the mouse's crosshairs
+            self._mouse_legend_options(index_x, index_y)
+
         else:
             self.hoverlegend.setVisible(False)
             self.vLine.setVisible(False)
             self.hLine.setVisible(False)
+
+    def _add_mouse_crosshairs(self, mousepoint):
+        # add crosshairs to the mouse's current location
+        if self._mouseMovedFunction is not None:
+            self._mouseMovedFunction(int(mousepoint.x()))
+            self.vLine.setPos(mousepoint.x())
+            self.hLine.setPos(mousepoint.y())
+            self.vLine.setVisible(True)
+            self.hLine.setVisible(True)
+
+    # Add legend options to the mouse's crosshairs
+    def _mouse_legend_options(self, index_x, index_y):
+        # Set legend options for the mouse crosshairs
+        self.hoverlegend.setVisible(True)
+        # Allow the user to set x-axis(time) and y-axis data names in crosshairs
+        self.hoverlegend.setItem(pytplot.data_quants[self.tvar_name].xaxis_opt['crosshair'] + ':', index_x)
+        self.hoverlegend.setItem(pytplot.data_quants[self.tvar_name].yaxis_opt['crosshair'] + ':', index_y)
 
     def _addlegend(self):
         if 'legend_names' in pytplot.data_quants[self.tvar_name].yaxis_opt:
@@ -185,9 +197,6 @@ class TVarFigureAlt(pg.GraphicsLayout):
             return pytplot.data_quants[self.tvar_name].extras['line_color']
         else:
             return pytplot.tplot_utilities.rgb_color(['k', 'r', 'seagreen', 'b', 'darkturquoise', 'm', 'goldenrod'])
-
-    def _setcolormap(self):
-        return
 
     def _setyrange(self):
         if self._getyaxistype() == 'log':

--- a/pytplot/QtPlotter/TVarFigureMap.py
+++ b/pytplot/QtPlotter/TVarFigureMap.py
@@ -98,9 +98,6 @@ class TVarFigureMap(pg.GraphicsLayout):
     def _setyaxislabel(self):
         self.yaxis.setLabel("Latitude", **self.labelStyle)
 
-    def _setyaxislabel(self):
-        self.yaxis.setLabel("Latitude")
-
     def getfig(self):
         return self
 
@@ -199,6 +196,10 @@ class TVarFigureMap(pg.GraphicsLayout):
         # if plot window contains position
         if self.plotwindow.sceneBoundingRect().contains(pos):
             mousepoint = self.plotwindow.vb.mapSceneToView(pos)
+
+            # Add crosshairs to plot at the mouse's position
+            self._add_mouse_crosshairs(mousepoint)
+
             # grab x and y mouse locations
             index_x = round(float(mousepoint.x()), 2)
             index_y = round(float(mousepoint.y()), 2)
@@ -217,30 +218,39 @@ class TVarFigureMap(pg.GraphicsLayout):
             # find closest time point to cursor
             radius = np.sqrt((latitude - index_y) ** 2 + (longitude - index_x) ** 2).argmin()
             time_point = time[radius]
-            # get date and time
-            date = (pytplot.tplot_utilities.int_to_str(time_point))[0:10]
-            time = (pytplot.tplot_utilities.int_to_str(time_point))[11:19]
 
-            # add crosshairs
-            if self._mouseMovedFunction is not None:
-                self._mouseMovedFunction(int(mousepoint.x()))
-                self.vLine.setVisible(True)
-                self.hLine.setVisible(True)
-                self.vLine.setPos(mousepoint.x())
-                self.hLine.setPos(mousepoint.y())
+            # Add legend options to the mouse's crosshairs
+            self._mouse_legend_options(time_point, index_x, index_y)
 
-            # Set legend options
-            self.hoverlegend.setVisible(True)
-            self.hoverlegend.setItem("Date: ", date)
-            self.hoverlegend.setItem("Time: ", time)
-            self.hoverlegend.setItem("Longitude:", str(index_x))
-            self.hoverlegend.setItem("Latitude:", str(index_y))
         else:
             self.hoverlegend.setVisible(False)
             self.vLine.setVisible(False)
             self.hLine.setVisible(False)
 
-    def _getyaxistype(self):
+    def _add_mouse_crosshairs(self, mousepoint):
+        # add crosshairs to the mouse's current location
+        if self._mouseMovedFunction is not None:
+            self._mouseMovedFunction(int(mousepoint.x()))
+            self.vLine.setVisible(True)
+            self.hLine.setVisible(True)
+            self.vLine.setPos(mousepoint.x())
+            self.hLine.setPos(mousepoint.y())
+
+    def _mouse_legend_options(self, time_point, index_x, index_y):
+        # Set legend options for the mouse crosshairs
+        # get date and time
+        date = (pytplot.tplot_utilities.int_to_str(time_point))[0:10]
+        time = (pytplot.tplot_utilities.int_to_str(time_point))[11:19]
+
+        # Set legend options
+        self.hoverlegend.setVisible(True)
+        self.hoverlegend.setItem("Date: ", date)
+        self.hoverlegend.setItem("Time: ", time)
+        self.hoverlegend.setItem("Longitude:", str(index_x))
+        self.hoverlegend.setItem("Latitude:", str(index_y))
+
+    @staticmethod
+    def _getyaxistype():
         return 'linear'
 
     def _setzaxistype(self):
@@ -270,7 +280,8 @@ class TVarFigureMap(pg.GraphicsLayout):
         else:
             return [pytplot.tplot_utilities.return_lut("inferno")]
 
-    def getaxistype(self):
+    @staticmethod
+    def getaxistype():
         axis_type = 'lat'
         link_y_axis = True
         return axis_type, link_y_axis


### PR DESCRIPTION
Addresses issue #57 

Just broke up the mousemoved functions in all the QtPlotter classes to try and be a bit more condensed in what they do. Moved the actual drawing of crosshairs/setting crosshair legend options outside of the mousemoved functions.