### PR TITLE
Bugfix for 1D vars that have depend_1's

### DIFF
--- a/pytplot/QtPlotter/TVarFigure1D.py
+++ b/pytplot/QtPlotter/TVarFigure1D.py
@@ -134,7 +134,8 @@ class TVarFigure1D(pg.GraphicsLayout):
             # TODO: The below function is essentially a hack for now, because this code was written assuming the data was a dataframe object.
             # This needs to be rewritten to use xarray
             plot_options = dataset.attrs['plot_options']
-            dataset = pytplot.tplot_utilities.convert_tplotxarray_to_pandas_dataframe(dataset.name)
+            dataset = pytplot.tplot_utilities.convert_tplotxarray_to_pandas_dataframe_lineplots(dataset.name)
+
             for i in range(len(dataset.columns)):
                 if 'line_style' in plot_options['line_opt']:
                     if plot_options['line_opt']['line_style'] == 'scatter':

--- a/pytplot/tplot_utilities.py
+++ b/pytplot/tplot_utilities.py
@@ -536,6 +536,12 @@ def set_y_range(var, y_axis_log, plot):
                            pytplot.data_quants[var].attrs['plot_options']['interactive_yaxis_opt']['yi_range'][1], padding=0)
 
 
+def convert_tplotxarray_to_pandas_dataframe_lineplots(name):
+    import pandas as pd
+    # copy of the function below, specifically for line plots
+    return_data = pd.DataFrame(pytplot.data_quants[name].values)
+    return_data = return_data.set_index(pd.Index(pytplot.data_quants[name].coords['time'].values))
+    return return_data
 
 def convert_tplotxarray_to_pandas_dataframe(name):
     import pandas as pd


### PR DESCRIPTION
Some THEMIS state variables have depend_1's for some reason, which causes a crash - this fixes it.