### PR TITLE
Do not add zero length data

### DIFF
--- a/pytplot/importers/cdf_to_tplot.py
+++ b/pytplot/importers/cdf_to_tplot.py
@@ -280,8 +280,13 @@ def cdf_to_tplot(filenames, varformat=None, get_support_data=False,
                 else:
                     var_data = output_table[var_name]
                     for output_var in var_data:
-                        if output_var not in nontime_varying_depends:
-                            var_data[output_var] = np.concatenate((var_data[output_var], tplot_data[output_var]))
+                        if output_var not in nontime_varying_depends:                        
+                            if np.asarray(tplot_data[output_var]).ndim == 0 and np.equal(tplot_data[output_var], None):
+                                pass
+                            elif np.asarray(var_data[output_var]).ndim == 0 and np.equal(var_data[output_var], None):
+                                var_data[output_var] = tplot_data[output_var]
+                            else:                                
+                                var_data[output_var] = np.concatenate((var_data[output_var], tplot_data[output_var]))
 
     if notplot:
         return output_table


### PR DESCRIPTION
If data is empty, then don't concatenate. This resolves a problem with FAST data, where some arrays contain None. Also, please note that numpy.array(None).size=1 but numpy.array(None).ndim=0. Here we exclude only the situation when the array contains a scalar and the scalar is 'None'.