### PR TITLE
Now requiring numpy 1.19.3 due to Windows 10 bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy <= 0.19.3
 bokeh >= 1.1
 pyqtgraph
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy <= 0.19.3
+numpy <= 1.19.3
 bokeh >= 1.1
 pyqtgraph
 pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ setup_requires =
 include_package_data = True
 packages = find:
 install_requires =
-  numpy <= 0.19.3
+  numpy <= 1.19.3
   bokeh >= 1.1
   pyqtgraph
   pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ setup_requires =
 include_package_data = True
 packages = find:
 install_requires =
-  numpy
+  numpy <= 0.19.3
   bokeh >= 1.1
   pyqtgraph
   pandas


### PR DESCRIPTION
There's an issue with numpy 1.19.4 on Windows 10. This bug should be fixed in Windows by the end of Jan 2021; for details, see:

https://tinyurl.com/y3dm3h86