### PR TITLE
Bumping version to require latest version of pyqtgraph

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytplot" %}
-{% set version = "1.7.12" %}
+{% set version = "1.7.15" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   git_url: https://github.com/MAVENSDC/pytplot.git
-  git_rev: v1.7.12
+  git_rev: v1.7.15
 
 build:
   number: 0

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytplot" %}
-{% set version = "1.7.11" %}
+{% set version = "1.7.12" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   git_url: https://github.com/MAVENSDC/pytplot.git
-  git_rev: v1.7.11
+  git_rev: v1.7.12
 
 build:
   number: 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytplot
-version = 1.7.11
+version = 1.7.12
 author = MAVEN SDC
 author_email = mavensdc@lasp.colorado.edu
 description = A python version of IDL tplot libraries

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytplot
-version = 1.7.12
+version = 1.7.15
 author = MAVEN SDC
 author_email = mavensdc@lasp.colorado.edu
 description = A python version of IDL tplot libraries


### PR DESCRIPTION
Updates to support Python 3.9, and fix bugs with plotting data with NaNs:
Updating required pyqtgraph version to 0.11.1
Updating required pyqt5 version to 5.15.2
Bumping required Python version to 3.6
