### PR TITLE
Several improvements

### DIFF
--- a/pytplot/QtPlotter/TVarFigure1D.py
+++ b/pytplot/QtPlotter/TVarFigure1D.py
@@ -376,6 +376,9 @@ class TVarFigure1D(pg.GraphicsLayout):
         if 'line_color' in pytplot.data_quants[self.tvar_name].attrs['plot_options']['extras']:
             return pytplot.tplot_utilities.rgb_color(pytplot.data_quants[self.tvar_name].attrs['plot_options']['extras']['line_color'])
         else:
+            if len(pytplot.data_quants[self.tvar_name].data.shape) > 1:
+                if pytplot.data_quants[self.tvar_name].data.shape[1] == 3:
+                    return pytplot.tplot_utilities.rgb_color(['b', 'g', 'r'])
             if pytplot.tplot_opt_glob["black_background"]:
                 return pytplot.tplot_utilities.rgb_color(['w', 'r', 'seagreen', 'b', 'darkturquoise', 'm', 'goldenrod'])
             else:

--- a/pytplot/QtPlotter/TVarFigureSpec.py
+++ b/pytplot/QtPlotter/TVarFigureSpec.py
@@ -425,7 +425,7 @@ class TVarFigureSpec(pg.GraphicsLayout):
             for cm in pytplot.data_quants[self.tvar_name].attrs['plot_options']['extras']['colormap']:
                 return tplot_utilities.return_lut(cm)
         else:
-            return tplot_utilities.return_lut("inferno")
+            return tplot_utilities.return_lut("jet")
 
     def _setxrange(self):
         # Check if x range is set.  Otherwise, x range is automatic.

--- a/pytplot/importers/cdf_to_tplot.py
+++ b/pytplot/importers/cdf_to_tplot.py
@@ -245,6 +245,11 @@ def cdf_to_tplot(filenames, varformat=None, get_support_data=False,
 
                         if ydata[ydata == var_atts["FILLVAL"]].size != 0:
                             ydata[ydata == var_atts["FILLVAL"]] = np.nan
+                    elif var_properties['Data_Type_Description'][:7] == 'CDF_INT':
+                        # NaN is only valid for floating point data
+                        # but we still need to handle FILLVAL's for
+                        # integer data, so we'll just set those to 0
+                        ydata[ydata == var_atts["FILLVAL"]] = 0
 
                 tplot_data = {'x': xdata, 'y': ydata}
 
@@ -357,6 +362,13 @@ def cdf_to_tplot(filenames, varformat=None, get_support_data=False,
                 options(var_name, 'spec', 1)
             if metadata[var_name]['scale_type'] == 'log':
                 options(var_name, 'ylog', 1)
+            if metadata[var_name].get('var_attrs') is not None:
+                if metadata[var_name]['var_attrs'].get('LABLAXIS') is not None:
+                    options(var_name, 'ytitle', metadata[var_name]['var_attrs']['LABLAXIS'])
+                if metadata[var_name]['var_attrs'].get('UNITS') is not None:
+                    options(var_name, 'ysubtitle', '[' + metadata[var_name]['var_attrs']['UNITS'] + ']')
+
+
             # Gather up all options in the variable attribute section, toss them into options and see what sticks
             options(var_name, opt_dict=metadata[var_name]['var_attrs'])
 

--- a/pytplot/importers/cdf_to_tplot.py
+++ b/pytplot/importers/cdf_to_tplot.py
@@ -366,8 +366,10 @@ def cdf_to_tplot(filenames, varformat=None, get_support_data=False,
                 if metadata[var_name]['var_attrs'].get('LABLAXIS') is not None:
                     options(var_name, 'ytitle', metadata[var_name]['var_attrs']['LABLAXIS'])
                 if metadata[var_name]['var_attrs'].get('UNITS') is not None:
-                    options(var_name, 'ysubtitle', '[' + metadata[var_name]['var_attrs']['UNITS'] + ']')
-
+                    if metadata[var_name]['display_type'] == 'spectrogram':
+                        options(var_name, 'ztitle', '[' + metadata[var_name]['var_attrs']['UNITS'] + ']')
+                    else:
+                        options(var_name, 'ysubtitle', '[' + metadata[var_name]['var_attrs']['UNITS'] + ']')
 
             # Gather up all options in the variable attribute section, toss them into options and see what sticks
             options(var_name, opt_dict=metadata[var_name]['var_attrs'])


### PR DESCRIPTION
- Improving default metadata (now using UNITS (ysubtitle) and LABLAXIS (ytitle) from the CDF variable attributes)
- setting fill values to 0 for integer data (Geotail MGF data is stored as CDF INTs)
- Now using the 'jet' color bar for spectrograms by default (this more closely matches the IDL SPEDAS color bar)
- Now defaulting colors to ['blue', 'green', 'red'] for 3-element vectors