### PR TITLE
Fix: Error if data is not string

### DIFF
--- a/pytplot/tplot_utilities.py
+++ b/pytplot/tplot_utilities.py
@@ -639,6 +639,11 @@ def get_y_range(dataset):
         y_min = np.nan
         y_max = np.nan
 
+    # CDF files may have array of strings (e.g., RBSP EMFISIS)
+    if isinstance(y_min, str):
+        y_min = np.nan
+        y_max = np.nan
+        
     if y_min == y_max:
         # Show 10% and 10% below the straight line
         y_min = y_min - (.1 * np.abs(y_min))


### PR DESCRIPTION
Some CDF files have data of an array of strings. 
This function will create an error during those instances. 
The min and max is set to NaN for those instances. 

code to reproduce the error
import pyspedas
emfisis_vars = pyspedas.rbsp.emfisis(trange=['2018-10-7', '2018-11-6'], probe='a', datatype='density', level='l4')