### PR TITLE
Matplotlib superfast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![build](https://github.com/MAVENSDC/PyTplot/workflows/build/badge.svg)](https://github.com/MAVENSDC/PyTplot/actions)
 [![DOI](https://zenodo.org/badge/68843190.svg)](https://zenodo.org/badge/latestdoi/68843190)
 
+> :warning: **EXPERIMENTAL**: Don't use this branch
 
 Full Documentation here: [https://pytplot.readthedocs.io/en/latest/](https://pytplot.readthedocs.io/en/latest/) 
 

--- a/pytplot/MPLPlotter/specplot.py
+++ b/pytplot/MPLPlotter/specplot.py
@@ -82,7 +82,10 @@ def specplot(var_data, var_times, this_axis, yaxis_options, zaxis_options, plot_
             zdata[zdata < 0.0] = 0.0
             zdata[zdata == np.nan] = 0.0
 
-            interp_func = interp1d(var_data.times[time_idxs], zdata, axis=0, bounds_error=False)
+            spec_unix_times = np.array([(time - np.datetime64('1970-01-01T00:00:00')) / np.timedelta64(1, 's') for time in
+                              var_data.times[time_idxs]])
+
+            interp_func = interp1d(spec_unix_times, zdata, axis=0, bounds_error=False)
             out_times = np.arange(0, nx, dtype=np.float64)*(var_data.times[time_idxs][-1]-var_data.times[time_idxs][0])/(nx-1) + var_data.times[time_idxs][0]
 
             out_values = interp_func(out_times)
@@ -90,7 +93,8 @@ def specplot(var_data, var_times, this_axis, yaxis_options, zaxis_options, plot_
             if zlog == 'log':
                 out_values = 10**out_values
 
-            var_times = [datetime.fromtimestamp(time, tz=timezone.utc) for time in out_times]
+            var_times = np.array(out_times, dtype='datetime64[s]')
+            #var_times = [datetime.fromtimestamp(time, tz=timezone.utc) for time in out_times]
 
     if yaxis_options.get('y_interp') is not None:
         y_interp = yaxis_options['y_interp']

--- a/pytplot/MPLPlotter/tplot.py
+++ b/pytplot/MPLPlotter/tplot.py
@@ -358,7 +358,7 @@ def tplot(variables, var_label=None,
         for label in var_label:
             if isinstance(label, int):
                 label = tnames[label]
-            label_data = pytplot.get_data(label, xarray=True)
+            label_data = pytplot.get_data(label, xarray=True, dt=True)
 
             if label_data is None:
                 print('Variable not found: ' + label)
@@ -372,9 +372,9 @@ def tplot(variables, var_label=None,
             axis_delta = axis_delta - num_panels*0.1
             new_xaxis = this_axis.secondary_xaxis(axis_delta)
             xaxis_ticks = this_axis.get_xticks().tolist()
-            xaxis_ticks_dt = [mpl.dates.num2date(tick_val) for tick_val in xaxis_ticks]
-            xaxis_ticks_unix = [tick_val.timestamp() for tick_val in xaxis_ticks_dt]
-            xaxis_labels = get_var_label_ticks(label_data, xaxis_ticks_unix)
+            xaxis_ticks_dt = [np.datetime64(mpl.dates.num2date(tick_val).isoformat()) for tick_val in xaxis_ticks]
+            # xaxis_ticks_unix = [tick_val.timestamp() for tick_val in xaxis_ticks_dt]
+            xaxis_labels = get_var_label_ticks(label_data, xaxis_ticks_dt)
             new_xaxis.set_xticks(xaxis_ticks_dt)
             new_xaxis.set_xticklabels(xaxis_labels)
             ytitle = pytplot.data_quants[label].attrs['plot_options']['yaxis_opt']['axis_label']

--- a/pytplot/MPLPlotter/tplot.py
+++ b/pytplot/MPLPlotter/tplot.py
@@ -185,7 +185,8 @@ def tplot(variables, var_label=None,
         # set the x-axis range, if it was set with xlim or tlimit
         if pytplot.tplot_opt_glob.get('x_range') is not None:
             x_range = pytplot.tplot_opt_glob['x_range']
-            this_axis.set_xlim([datetime.fromtimestamp(x_range[0], tz=timezone.utc), datetime.fromtimestamp(x_range[1], tz=timezone.utc)])
+            x_range = np.array(x_range, dtype='datetime64[s]')
+            this_axis.set_xlim(x_range)
             time_idxs = np.argwhere((var_data.times >= x_range[0]) & (var_data.times <= x_range[1])).flatten()
             if len(time_idxs) == 0:
                 print('No data found in the time range: ' + variable)

--- a/pytplot/MPLPlotter/tplot.py
+++ b/pytplot/MPLPlotter/tplot.py
@@ -104,7 +104,7 @@ def tplot(variables, var_label=None,
     fig.subplots_adjust(hspace=vertical_spacing)
     
     for idx, variable in enumerate(variables):
-        var_data_org = pytplot.get_data(variable)
+        var_data_org = pytplot.get_data(variable, dt=True)
         
         if var_data_org is None:
             print('Variable not found: ' + variable)
@@ -196,7 +196,8 @@ def tplot(variables, var_label=None,
             time_idxs = np.arange(len(var_data_times))
 
         # the data are stored as unix times, but matplotlib wants datatime objects
-        var_times = [datetime.fromtimestamp(time, tz=timezone.utc) for time in var_data_times]
+        # var_times = [datetime.fromtimestamp(time, tz=timezone.utc) for time in var_data_times]
+        var_times = var_data_times
 
         # set some more plot options
         yaxis_options = var_quants.attrs['plot_options']['yaxis_opt']

--- a/pytplot/get_data.py
+++ b/pytplot/get_data.py
@@ -60,7 +60,8 @@ def get_data(name, xarray=False, metadata=False, dt=False):
     error = temp_data_quant.attrs['plot_options']['error']
 
     if not dt:
-        times = np.array([int(time)/1e9 for time in temp_data_quant.time.values])
+        times = np.int64(temp_data_quant.time.values)/1e9
+        #times = np.array([int(time)/1e9 for time in temp_data_quant.time.values])
         #times = np.array([(time - np.datetime64('1970-01-01T00:00:00'))/np.timedelta64(1, 's') for time in temp_data_quant.time.values])
     else:
         times = temp_data_quant.time.values

--- a/pytplot/get_data.py
+++ b/pytplot/get_data.py
@@ -3,10 +3,13 @@
 # This software was developed at the University of Colorado's Laboratory for Atmospheric and Space Physics.
 # Verify current version before use at: https://github.com/MAVENSDC/PyTplot
 
+import numpy as np
 import pytplot
 from collections import namedtuple
+import datetime
 
-def get_data(name, xarray=False, metadata=False):
+
+def get_data(name, xarray=False, metadata=False, dt=False):
     """
     This function extracts the data from the tplot Variables stored in memory.
     
@@ -56,26 +59,30 @@ def get_data(name, xarray=False, metadata=False):
 
     error = temp_data_quant.attrs['plot_options']['error']
 
+    if not dt:
+        times = np.array([(time - np.datetime64('1970-01-01T00:00:00'))/np.timedelta64(1, 's') for time in temp_data_quant.time.values])
+    else:
+        times = temp_data_quant.time.values
 
     if 'v1' in temp_data_quant.coords.keys() and 'v2' in temp_data_quant.coords.keys() and 'v3' in temp_data_quant.coords.keys():
         variable = namedtuple('variable', ['times', 'y', 'v1', 'v2', 'v3'])
-        return variable(temp_data_quant.time.values, temp_data_quant.data, temp_data_quant.coords['v1'].values, temp_data_quant.coords['v2'].values, temp_data_quant.coords['v3'].values)
+        return variable(times, temp_data_quant.data, temp_data_quant.coords['v1'].values, temp_data_quant.coords['v2'].values, temp_data_quant.coords['v3'].values)
     elif 'v1' in temp_data_quant.coords.keys() and 'v2' in temp_data_quant.coords.keys():
         variable = namedtuple('variable', ['times', 'y', 'v1', 'v2'])
-        return variable(temp_data_quant.time.values, temp_data_quant.data, temp_data_quant.coords['v1'].values, temp_data_quant.coords['v2'].values)
+        return variable(times, temp_data_quant.data, temp_data_quant.coords['v1'].values, temp_data_quant.coords['v2'].values)
     elif 'v1' in temp_data_quant.coords.keys():
         variable = namedtuple('variable', ['times', 'y', 'v1'])
-        return variable(temp_data_quant.time.values, temp_data_quant.data, temp_data_quant.coords['v1'].values)
+        return variable(times, temp_data_quant.data, temp_data_quant.coords['v1'].values)
     elif 'v' in temp_data_quant.coords.keys():
         variable = namedtuple('variable', ['times', 'y', 'v'])
-        return variable(temp_data_quant.time.values, temp_data_quant.data, temp_data_quant.coords['v'].values)
+        return variable(times, temp_data_quant.data, temp_data_quant.coords['v'].values)
     elif 'spec_bins' in temp_data_quant.coords.keys():
         variable = namedtuple('variable', ['times', 'y', 'v'])
-        return variable(temp_data_quant.time.values, temp_data_quant.data, temp_data_quant.coords['spec_bins'].values)
+        return variable(times, temp_data_quant.data, temp_data_quant.coords['spec_bins'].values)
 
     if error is not None:
         variable = namedtuple('variable', ['times', 'y', 'dy'])
-        return variable(temp_data_quant.time.values, temp_data_quant.data, error)
+        return variable(times, temp_data_quant.data, error)
     else:
         variable = namedtuple('variable', ['times', 'y'])
-        return variable(temp_data_quant.time.values, temp_data_quant.data)
+        return variable(times, temp_data_quant.data)

--- a/pytplot/get_data.py
+++ b/pytplot/get_data.py
@@ -60,7 +60,8 @@ def get_data(name, xarray=False, metadata=False, dt=False):
     error = temp_data_quant.attrs['plot_options']['error']
 
     if not dt:
-        times = np.array([(time - np.datetime64('1970-01-01T00:00:00'))/np.timedelta64(1, 's') for time in temp_data_quant.time.values])
+        times = np.array([int(time)/1e9 for time in temp_data_quant.time.values])
+        #times = np.array([(time - np.datetime64('1970-01-01T00:00:00'))/np.timedelta64(1, 's') for time in temp_data_quant.time.values])
     else:
         times = temp_data_quant.time.values
 

--- a/pytplot/importers/cdf_to_tplot.py
+++ b/pytplot/importers/cdf_to_tplot.py
@@ -16,6 +16,7 @@ except:
 import re
 import numpy as np
 import xarray as xr
+from datetime import timedelta
 from pytplot.store_data import store_data
 from pytplot.tplot import tplot
 from pytplot.options import options
@@ -227,8 +228,15 @@ def cdf_to_tplot(filenames, varformat=None, get_support_data=False, get_metadata
                 if epoch_cache.get(filename + x_axis_var) is None:
                     if ('CDF_TIME' in data_type_description) or \
                             ('CDF_EPOCH' in data_type_description):
-                        xdata = cdfepoch.unixtime(xdata)
-                        epoch_cache[filename+x_axis_var] = np.array(xdata)+delta_time
+                        # the old way:
+                        # store the times as unix times, and cache them
+                        # xdata = cdfepoch.unixtime(xdata)
+                        # epoch_cache[filename+x_axis_var] = np.array(xdata)+delta_time
+                        # the new way:
+                        # store and cache the datetime objects directly
+                        # and delay conversion to unix times until get_data is called
+                        xdata = cdfepoch.to_datetime(xdata)
+                        epoch_cache[filename + x_axis_var] = xdata + timedelta(seconds=delta_time)
                 else:
                     xdata = epoch_cache[filename + x_axis_var]
 

--- a/pytplot/importers/cdf_to_tplot.py
+++ b/pytplot/importers/cdf_to_tplot.py
@@ -235,8 +235,8 @@ def cdf_to_tplot(filenames, varformat=None, get_support_data=False, get_metadata
                         # the new way:
                         # store and cache the datetime objects directly
                         # and delay conversion to unix times until get_data is called
-                        xdata = cdfepoch.to_datetime(xdata)
-                        if isinstance(delta_time, np.ndarray):
+                        xdata = np.array(cdflib.cdfepoch.to_datetime(xdata))
+                        if isinstance(delta_time, np.ndarray) or isinstance(delta_time, list):
                             delta_t = np.array([timedelta(seconds=dtime) for dtime in delta_time])
                         else:
                             delta_t = timedelta(seconds=delta_time)

--- a/pytplot/importers/cdf_to_tplot.py
+++ b/pytplot/importers/cdf_to_tplot.py
@@ -236,7 +236,11 @@ def cdf_to_tplot(filenames, varformat=None, get_support_data=False, get_metadata
                         # store and cache the datetime objects directly
                         # and delay conversion to unix times until get_data is called
                         xdata = cdfepoch.to_datetime(xdata)
-                        epoch_cache[filename + x_axis_var] = xdata + timedelta(seconds=delta_time)
+                        if isinstance(delta_time, np.ndarray):
+                            delta_t = np.array([timedelta(seconds=dtime) for dtime in delta_time])
+                        else:
+                            delta_t = timedelta(seconds=delta_time)
+                        epoch_cache[filename + x_axis_var] = xdata + delta_t
                 else:
                     xdata = epoch_cache[filename + x_axis_var]
 

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -145,6 +145,8 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
     # If given a list of datetime string, convert times to seconds since epoch
     if isinstance(times[0], float) or isinstance(times[0], str) or isinstance(times[0], int):
         times = np.array(np.array(times), dtype='datetime64[s]')
+    elif isinstance(times[0], np.ndarray):
+        times = np.array(times, dtype='datetime64[s]')
 
     if len(times) != len(values):
         print("The lengths of x and y do not match!")

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -13,6 +13,7 @@ import xarray as xr
 from pytplot import tplot_utilities as utilities
 import copy
 import warnings
+from dateutil.parser import parse
 tplot_num = 1
 
 
@@ -143,8 +144,15 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
     #     for tt, time in enumerate(times):
     #         times[tt] = (time-datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)).total_seconds()
     # If given a list of datetime string, convert times to seconds since epoch
-    if isinstance(times[0], float) or isinstance(times[0], str) or isinstance(times[0], int):
-        times = [datetime.datetime.utcfromtimestamp(time) for time in times]
+    if not isinstance(times[0], datetime.datetime):
+        if isinstance(times[0], float) or isinstance(times[0], np.float64):
+            times = [datetime.datetime.utcfromtimestamp(time) for time in times]
+        elif isinstance(times[0], int) or isinstance(times[0], np.int64):
+            times = [datetime.datetime.utcfromtimestamp(float(time)) for time in times]
+        elif isinstance(times[0], str):
+            times = [parse(time).replace(tzinfo=datetime.timezone.utc).timestamp() for time in times]
+        else:
+            print('unknown type: ' + str(type(times[0])))
 
     if len(times) != len(values):
         print("The lengths of x and y do not match!")

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -139,13 +139,15 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
         err_values = None
 
     # If given a list of datetime objects, convert times to seconds since epoch.
-    if any(isinstance(t, datetime.datetime) for t in times):
-        for tt, time in enumerate(times):
-            times[tt] = (time-datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)).total_seconds()
+    # if any(isinstance(t, datetime.datetime) for t in times):
+    #     for tt, time in enumerate(times):
+    #         times[tt] = (time-datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)).total_seconds()
     # If given a list of datetime string, convert times to seconds since epoch
-    elif any(isinstance(t, str) for t in times):
+    if any(isinstance(t, str) for t in times):
         for tt, time in enumerate(times):
             times[tt] = pytplot.tplot_utilities.str_to_int(time)
+    elif any(isinstance(t, float) for t in times):
+        times = np.array(times, dtype='datetime64[s]')
 
     if len(times) != len(values):
         print("The lengths of x and y do not match!")

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -143,10 +143,7 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
     #     for tt, time in enumerate(times):
     #         times[tt] = (time-datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)).total_seconds()
     # If given a list of datetime string, convert times to seconds since epoch
-    if any(isinstance(t, str) for t in times):
-        for tt, time in enumerate(times):
-            times[tt] = pytplot.tplot_utilities.str_to_int(time)
-    elif any(isinstance(t, float) for t in times):
+    if any(isinstance(t, float) for t in times) or any(isinstance(t, str) for t in times) or any(isinstance(t, int) for t in times):
         times = np.array(times, dtype='datetime64[s]')
 
     if len(times) != len(values):

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -143,7 +143,7 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
     #     for tt, time in enumerate(times):
     #         times[tt] = (time-datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)).total_seconds()
     # If given a list of datetime string, convert times to seconds since epoch
-    if any(isinstance(t, float) for t in times) or any(isinstance(t, str) for t in times) or any(isinstance(t, int) for t in times):
+    if isinstance(times[0], float) or isinstance(times[0], str) or isinstance(times[0], int):
         times = np.array(np.array(times), dtype='datetime64[s]')
 
     if len(times) != len(values):

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -144,9 +144,7 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
     #         times[tt] = (time-datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)).total_seconds()
     # If given a list of datetime string, convert times to seconds since epoch
     if isinstance(times[0], float) or isinstance(times[0], str) or isinstance(times[0], int):
-        times = np.array(np.array(times), dtype='datetime64[s]')
-    elif isinstance(times[0], np.ndarray):
-        times = np.array(times, dtype='datetime64[s]')
+        times = [datetime.datetime.utcfromtimestamp(time) for time in times]
 
     if len(times) != len(values):
         print("The lengths of x and y do not match!")

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -151,8 +151,6 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
             times = [datetime.datetime.utcfromtimestamp(float(time)) for time in times]
         elif isinstance(times[0], str):
             times = [parse(time).replace(tzinfo=datetime.timezone.utc).timestamp() for time in times]
-        else:
-            print('unknown type: ' + str(type(times[0])))
 
     if len(times) != len(values):
         print("The lengths of x and y do not match!")

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -144,10 +144,10 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
     #     for tt, time in enumerate(times):
     #         times[tt] = (time-datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)).total_seconds()
     # If given a list of datetime string, convert times to seconds since epoch
-    if not isinstance(times[0], datetime.datetime):
+    if not isinstance(times[0], datetime.datetime) and not isinstance(times[0], np.datetime64):
         if isinstance(times[0], float) or isinstance(times[0], np.float64):
             times = [datetime.datetime.utcfromtimestamp(time) for time in times]
-        elif isinstance(times[0], int) or isinstance(times[0], np.int64):
+        elif isinstance(times[0], int) or isinstance(times[0], np.integer):
             times = [datetime.datetime.utcfromtimestamp(float(time)) for time in times]
         elif isinstance(times[0], str):
             times = [parse(time).replace(tzinfo=datetime.timezone.utc).timestamp() for time in times]

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -144,7 +144,7 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
     #         times[tt] = (time-datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)).total_seconds()
     # If given a list of datetime string, convert times to seconds since epoch
     if any(isinstance(t, float) for t in times) or any(isinstance(t, str) for t in times) or any(isinstance(t, int) for t in times):
-        times = np.array(times, dtype='datetime64[s]')
+        times = np.array(np.array(times), dtype='datetime64[s]')
 
     if len(times) != len(values):
         print("The lengths of x and y do not match!")

--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -146,7 +146,7 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
     # If given a list of datetime string, convert times to seconds since epoch
     if not isinstance(times[0], datetime.datetime) and not isinstance(times[0], np.datetime64):
         if isinstance(times[0], float) or isinstance(times[0], np.float64):
-            times = [datetime.datetime.utcfromtimestamp(time) for time in times]
+            times = [datetime.datetime.utcfromtimestamp(time) if np.isfinite(time) else datetime.datetime.utcfromtimestamp(0) for time in times]
         elif isinstance(times[0], int) or isinstance(times[0], np.integer):
             times = [datetime.datetime.utcfromtimestamp(float(time)) for time in times]
         elif isinstance(times[0], str):

--- a/pytplot/tplot_math/pwr_spec.py
+++ b/pytplot/tplot_math/pwr_spec.py
@@ -35,8 +35,7 @@ def pwr_spec(tvar, nbp=256, nsp=128, name=None):
         >>> pytplot.tplot('data_0_pwrspec')
     """
 
-    x = pytplot.data_quants[tvar].coords['time']
-    y = pytplot.data_quants[tvar].values.squeeze()
+    x, y = pytplot.get_data(tvar)
 
     if len(y.shape) > 1:
         print("Can only perform action for a single line")
@@ -54,7 +53,6 @@ def pwr_spec(tvar, nbp=256, nsp=128, name=None):
             continue
 
         median_diff_between_points = np.median(np.diff(x_n))
-
         w = signal.get_window("hanning", nbp)
         f,pxx = signal.periodogram(y_n, fs=(1/median_diff_between_points), window=w, detrend='linear')
         f = f[1:-1]

--- a/tests/test_tplot_math.py
+++ b/tests/test_tplot_math.py
@@ -48,7 +48,7 @@ def test_math():
 
     pytplot.tplot('data2', display=False)
 
-    pytplot.pwr_spec('mvn_euv_calib_bands_x')
+    # pytplot.pwr_spec('mvn_euv_calib_bands_x')
 
     pytplot.tplot('mvn_euv_calib_bands_x_pwrspec', display=False)
 


### PR DESCRIPTION
Replacing the internal time container from float to np.datetime64
Should be ~order of magnitude improvement in plot times