### PR TITLE
Update mode in reading file

### DIFF
--- a/pytplot/importers/netcdf_to_tplot.py
+++ b/pytplot/importers/netcdf_to_tplot.py
@@ -75,7 +75,7 @@ def netcdf_to_tplot(filenames, time='', prefix='', suffix='', plot=False, merge=
     for filename in filenames:
 
         # Read in file
-        file = Dataset(filename, "r+")
+        file = Dataset(filename)
 
         # Creating dictionary that will contain variables and their attributes
         vars_and_atts = {}


### PR DESCRIPTION
When reading in file, one does not need write access.

Reading files with write access will raise error for some data products (like `GOES-R mpsh` data)
-  read file in `r+` mode raise `OSError: [Errno -101] NetCDF: HDF error`, 
- read file in `w` mode raise `PermissionError: [Errno 13] Permission denied`