### PR TITLE
Add options for y major and minor ticks

### DIFF
--- a/pytplot/MPLPlotter/tplot.py
+++ b/pytplot/MPLPlotter/tplot.py
@@ -313,6 +313,10 @@ def tplot(variables, var_label=None,
         if ymajor_ticks is not None:
             this_axis.set_yticks(ymajor_ticks)
 
+        yminor_tick_interval = yaxis_options.get('y_minor_tick_interval')
+        if yminor_tick_interval is not None and ylog != 'log':
+            this_axis.yaxis.set_minor_locator(plt.MultipleLocator(yminor_tick_interval))
+
         if style is None:
             ytitle_color = 'black'
         else:

--- a/pytplot/MPLPlotter/tplot.py
+++ b/pytplot/MPLPlotter/tplot.py
@@ -23,16 +23,16 @@ munits.registry[datetime] = converter
 def tplot(variables, var_label=None,
                      xsize=None,
                      ysize=None,
-                     save_png='', 
-                     save_eps='', 
-                     save_svg='', 
+                     save_png='',
+                     save_eps='',
+                     save_svg='',
                      save_pdf='',
                      save_jpeg='',
                      dpi=None,
-                     display=True, 
-                     fig=None, 
-                     axis=None, 
-                     pseudo_plot_num=None, 
+                     display=True,
+                     fig=None,
+                     axis=None,
+                     pseudo_plot_num=None,
                      pseudo_right_axis=False,
                      pseudo_yaxis_options=None,
                      pseudo_zaxis_options=None,
@@ -99,7 +99,7 @@ def tplot(variables, var_label=None,
         else:
             # using previous axis
             axes = axis.twinx()
-    
+
     plot_title = pytplot.tplot_opt_glob['title_text']
     axis_font_size = pytplot.tplot_opt_glob.get('axis_font_size')
     vertical_spacing = pytplot.tplot_opt_glob.get('vertical_spacing')
@@ -119,20 +119,20 @@ def tplot(variables, var_label=None,
 
     if vertical_spacing is None:
         vertical_spacing = 0.07
-    
+
     fig.subplots_adjust(hspace=vertical_spacing)
-    
+
     for idx, variable in enumerate(variables):
         var_data_org = pytplot.get_data(variable, dt=True)
         var_metadata = pytplot.get_data(variable, metadata=True)
-        
+
         if var_data_org is None:
             logging.info('Variable not found: ' + variable)
             continue
 
         var_data = copy.deepcopy(var_data_org)
 
-        # plt.subplots returns a list of axes for multiple panels 
+        # plt.subplots returns a list of axes for multiple panels
         # but only a single axis for a single panel
         if num_panels == 1:
             this_axis = axes
@@ -188,10 +188,10 @@ def tplot(variables, var_label=None,
                     line_opts = var_quants.attrs['plot_options']['line_opt']
 
             for pseudo_idx, var in enumerate(pseudo_vars):
-                tplot(var, return_plot_objects=return_plot_objects, 
-                        xsize=xsize, ysize=ysize, save_png=save_png, 
-                        save_eps=save_eps, save_svg=save_svg, save_pdf=save_pdf, 
-                        fig=fig, axis=this_axis, display=False, 
+                tplot(var, return_plot_objects=return_plot_objects,
+                        xsize=xsize, ysize=ysize, save_png=save_png,
+                        save_eps=save_eps, save_svg=save_svg, save_pdf=save_pdf,
+                        fig=fig, axis=this_axis, display=False,
                         pseudo_plot_num=pseudo_idx, second_axis_size=0.1,
                         pseudo_yaxis_options=yaxis_options, pseudo_zaxis_options=zaxis_options,
                         pseudo_line_options=line_opts, pseudo_extra_options=plot_extras,
@@ -201,7 +201,7 @@ def tplot(variables, var_label=None,
         # set the figure title
         if idx == 0 and plot_title != '':
             this_axis.set_title(plot_title)
-        
+
         #if data_gap is an option for this variable, or if it's a add
         #gaps here; an individual gap setting should override the
         #global setting
@@ -276,11 +276,11 @@ def tplot(variables, var_label=None,
             this_axis.set_yscale('log')
         else:
             this_axis.set_yscale('linear')
-            
+
         ytitle = yaxis_options['axis_label']
         if ytitle == '':
             ytitle = variable
-        
+
         ysubtitle = ''
         if yaxis_options.get('axis_subtitle') is not None:
             ysubtitle = yaxis_options['axis_subtitle']
@@ -308,6 +308,10 @@ def tplot(variables, var_label=None,
             if not np.isfinite(yrange[1]):
                 yrange[1] = None
             this_axis.set_ylim(yrange)
+
+        ymajor_ticks = yaxis_options.get('y_major_ticks')
+        if ymajor_ticks is not None:
+            this_axis.set_yticks(ymajor_ticks)
 
         if style is None:
             ytitle_color = 'black'
@@ -375,7 +379,7 @@ def tplot(variables, var_label=None,
             plot_created = lineplot(var_data, var_times, this_axis, line_opts, yaxis_options, plot_extras, pseudo_plot_num=pseudo_plot_num, time_idxs=time_idxs, style=style, var_metadata=var_metadata)
             if not plot_created:
                 continue
-            
+
         # apply any vertical/horizontal bars
         if pytplot.data_quants[variable].attrs['plot_options'].get('time_bar') is not None:
             time_bars = pytplot.data_quants[variable].attrs['plot_options']['time_bar']
@@ -523,7 +527,7 @@ def tplot(variables, var_label=None,
 
     if return_plot_objects:
         return fig, axes
-    
+
     if save_png is not None and save_png != '':
         plt.savefig(save_png + '.png', dpi=dpi)
 

--- a/pytplot/options.py
+++ b/pytplot/options.py
@@ -78,9 +78,11 @@ def options(name, option=None, value=None, opt_dict=None):
         border              bool         Turns on or off the top/right axes that would create a box around the plot
         var_label_ticks     int          Sets the number of ticks if this variable is displayed as an alternative x axis
 
-        data_gap            numerical    If there is a gap in the data larger than this number in seconds, then insert 
-                                         NaNs. This is similar to using the degap procedure on the variable, but is 
+        data_gap            numerical    If there is a gap in the data larger than this number in seconds, then insert
+                                         NaNs. This is similar to using the degap procedure on the variable, but is
                                          applied at plot-time, and does not persist in the variable data.
+        y_major_ticks       list         A list of values that will be used to set the major ticks on the y axis.
+        y_minor_tick_interval numerical  The interval between minor ticks on the y axis.
         =================== ==========   =====
     Returns:
         None
@@ -318,7 +320,7 @@ def options(name, option=None, value=None, opt_dict=None):
 
             if option == 'elinewidth':
                 pytplot.data_quants[i].attrs['plot_options']['line_opt']['elinewidth'] = value
-                
+
             if option == 'marker_size':
                 pytplot.data_quants[i].attrs['plot_options']['line_opt']['marker_size'] = value
 
@@ -371,6 +373,20 @@ def options(name, option=None, value=None, opt_dict=None):
                 pytplot.data_quants[i].attrs['plot_options']['yaxis_opt']['y_range'] = [value[0], value[1]]
                 # track whether the yrange option was set by the user
                 pytplot.data_quants[i].attrs['plot_options']['yaxis_opt']['y_range_user'] = True
+
+            if option == 'y_major_ticks':
+                # check whether the value is 1D array-like
+                if isinstance(value, (list, np.ndarray)):
+                    pytplot.data_quants[i].attrs['plot_options']['yaxis_opt']['y_major_ticks'] = value
+                else:
+                    logging.warning('y_major_ticks must be a 1D array-like object')
+
+            if option == 'y_minor_tick_interval':
+                # check whether the value is a number
+                if isinstance(value, (int, float)):
+                    pytplot.data_quants[i].attrs['plot_options']['yaxis_opt']['y_minor_tick_interval'] = value
+                else:
+                    logging.warning('y_minor_tick_interval must be a number')
 
             if option == 'zrange' or option == 'z_range':
                 pytplot.data_quants[i].attrs['plot_options']['zaxis_opt']['z_range'] = [value[0], value[1]]


### PR DESCRIPTION
I added two options related to y-axis ticks.
The first specifies the value at which the ticks are labeled. For example, when creating a plot where the x-axis is time and the y-axis is the pitch angle of the particles, the y-axis ticks should be 0, 90, 180, etc.
The second specifies the width of the minor ticks on the y-axis.