### PR TITLE
If times is a pandas series, change it to numpy array.

### DIFF
--- a/pytplot/store_data.py
+++ b/pytplot/store_data.py
@@ -145,7 +145,8 @@ def store_data(name, data=None, delete=False, newname=None, attr_dict={}):
         err_values = None
 
     # Convert input time representation to datetime objects, if needed
-
+    if isinstance(times, pd.core.series.Series):
+        times = times.to_numpy()  # if it is pandas series, convert to numpy array
     if not isinstance(times[0], datetime.datetime) and not isinstance(times[0], np.datetime64):
         if isinstance(times[0], float) or isinstance(times[0], np.float64):
             times = [datetime.datetime.utcfromtimestamp(time) if np.isfinite(time) else datetime.datetime.utcfromtimestamp(0) for time in times]


### PR DESCRIPTION
When 'times' is a pandas series, calling times[0] causes a deprecation warning.